### PR TITLE
Make it possible to inherit from ZodiosHookClass

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -96,9 +96,9 @@ export type ImmutableInfiniteQueryOptions<TQueryFnData, TData> = Omit<
 
 export class ZodiosHooksClass<Api extends ZodiosEndpointDefinitions> {
   constructor(
-    private readonly apiName: string,
-    private readonly zodios: ZodiosInstance<Api>,
-    private readonly options: { shouldAbortOnUnmount?: boolean } = {}
+    protected readonly apiName: string,
+    protected readonly zodios: ZodiosInstance<Api>,
+    protected readonly options: { shouldAbortOnUnmount?: boolean } = {}
   ) {
     this.injectAliasEndpoints();
   }


### PR DESCRIPTION
I'm trying to extend ZodiosClass with some dependent features like prefetching queries for SSR. But I got an obvious error
```
Class 'ZodiusHooksPrefetch<Api>' incorrectly extends base class 'ZodiosHooksClass<Api>'.
  Types have separate declarations of a private property 'apiName'
```

This small change of modifiers keeps required to be private properties private, makes the typescript compiler happy, and lets it extend hooks API without errors.

```typescript
class ZodiusHooksPrefetch<Api extends ZodiosEndpointDefinitions> extends ZodiosHooksClass<Api> {
  constructor(
    protected readonly apiName: string,
    protected readonly zodios: ZodiosInstance<Api>,
    protected readonly options: { shouldAbortOnUnmount?: boolean } = {}
  ) {
    super(apiName, zodios, options);
  }
}
```